### PR TITLE
get-underlying-property-name

### DIFF
--- a/src/TabBlazor/Components/Tables/Components/Column.razor.cs
+++ b/src/TabBlazor/Components/Tables/Components/Column.razor.cs
@@ -20,7 +20,10 @@ namespace TabBlazor
             get { return _title ?? Property.GetPropertyMemberInfo()?.Name; }
             set { _title = value; }
         }
-
+        public string PropertyName
+        {
+            get { return  Property.GetPropertyMemberInfo()?.Name; }
+        }
         [CascadingParameter(Name = "Table")] public ITable<Item> Table { get; set; }
         [Parameter] public string Width { get; set; }
         [Parameter] public bool Sortable { get; set; }


### PR DESCRIPTION
just required for server side data factory for sorting purposes, just to simplyfy code implementation for server calls.