### PR TITLE
support LTS

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
+      
+      - name: Setup .NET Core LTS
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
 
       - name: Setting up .NET Core SDK ${{ env.NETCORE_VERSION }}...
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
         # Checkout the code
         - uses: actions/checkout@v2
+        
+        - name: Setup .NET Core LTS
+          uses: actions/setup-dotnet@v1
+          with:
+            dotnet-version: 6.0.x
 
         - name: Setup .NET Core
           uses: actions/setup-dotnet@v1

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -10,6 +10,11 @@ jobs:
       # Checkout the code
       - uses: actions/checkout@v2
       
+      - name: Setup .NET Core LTS
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       uses: actions/checkout@v1
 
         # Install .NET Core SDK
+    - name: Setup .NET Core LTS
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/Icons/IconGenerator/IconGenerator.csproj
+++ b/Icons/IconGenerator/IconGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+	  <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TabBlazor.Tests/TabBlazor.Tests.csproj
+++ b/TabBlazor.Tests/TabBlazor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+	  <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/docs/Tabler.Docs.Server/Tabler.Docs.Server.csproj
+++ b/docs/Tabler.Docs.Server/Tabler.Docs.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+	  <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.4" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.16" Condition="'$(TargetFramework)' == 'net6.0'" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" Condition="'$(TargetFramework)' == 'net7.0'" />
   </ItemGroup>
 
 </Project>

--- a/docs/Tabler.Docs.Wasm/Tabler.Docs.Wasm.csproj
+++ b/docs/Tabler.Docs.Wasm/Tabler.Docs.Wasm.csproj
@@ -1,17 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+		<TargetFrameworks>net7.0;net6.0</TargetFrameworks>
         <BlazorCacheBootResources>false</BlazorCacheBootResources>
         <WasmBuildNative>true</WasmBuildNative>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.4" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.4" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.16"  Condition="'$(TargetFramework)' == 'net6.0'"/>
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.5"  Condition="'$(TargetFramework)' == 'net7.0'"/>
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.16" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.5" PrivateAssets="all" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.16" Condition="'$(TargetFramework)' == 'net6.0'"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.5" Condition="'$(TargetFramework)' == 'net7.0'"/>
         <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.4" />
-        <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+		<PackageReference Include="System.Net.Http.Json" Version="6.0.1" Condition="'$(TargetFramework)' == 'net6.0'"/>
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.1" Condition="'$(TargetFramework)' == 'net7.0'"/>
     </ItemGroup>
 
     <Target Name="BuildClientAssets" AfterTargets="ComputeFilesToPublish">

--- a/docs/Tabler.Docs/Tabler.Docs.csproj
+++ b/docs/Tabler.Docs/Tabler.Docs.csproj
@@ -1,38 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Content Remove="compilerconfig.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="compilerconfig.json" />
-  </ItemGroup>
-
-   <ItemGroup>
-    <SupportedPlatform Include="browser" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+	</PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Blazor-ApexCharts" Version="0.9.16-beta" />
-    <PackageReference Include="ClosedXML" Version="0.100.3" />
-    <PackageReference Include="ColorCode.HTML" Version="2.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-  </ItemGroup>
+		<Content Remove="compilerconfig.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\TabBlazor\TabBlazor.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="compilerconfig.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Update="Components\Helpers\ClickOutside\Multiple.razor">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<SupportedPlatform Include="browser" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Blazor-ApexCharts" Version="0.9.16-beta" />
+		<PackageReference Include="ClosedXML" Version="0.100.3" />
+		<PackageReference Include="ColorCode.HTML" Version="2.0.14" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.16" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.5" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.16" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\TabBlazor\TabBlazor.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Update="Components\Helpers\ClickOutside\Multiple.razor">
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+		</Content>
+	</ItemGroup>
 
 </Project>

--- a/src/TabBlazor.QuickTable.EntityFramework/TabBlazor.QuickTable.EntityFramework.csproj
+++ b/src/TabBlazor.QuickTable.EntityFramework/TabBlazor.QuickTable.EntityFramework.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+		<TargetFrameworks>net7.0;net6.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.16" Condition="'$(TargetFramework)' == 'net6.0'"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" Condition="'$(TargetFramework)' == 'net7.0'"/>
         <PackageReference Include="Teronis.MSBuild.Packaging.ProjectBuildInPackage" Version="1.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/TabBlazor/TabBlazor.csproj
+++ b/src/TabBlazor/TabBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 		<PackageId>TabBlazor</PackageId>
 		<Description>Blazor dashboard admin theme based on Tabler UI. Minimal Javascript</Description>
 		<Authors>Joakim Dangården</Authors>
@@ -38,8 +38,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="LinqKit.Core" Version="1.2.4" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.16" Condition="'$(TargetFramework)' == 'net6.0'"/>
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.5" Condition="'$(TargetFramework)' == 'net7.0'"/>
+		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="6.0.16" Condition="'$(TargetFramework)' == 'net6.0'"/>
+		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.5" Condition="'$(TargetFramework)' == 'net7.0'"/>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
not for reverting Your change @joadan  but only for having your project usable on more static environments based on LTS framework versions,
may we keep it unless project will require dropping support of bit older framework versions ?
patch for: https://github.com/TabBlazor/TabBlazor/pull/109 I  hope you will accept it :) 
cheers! 